### PR TITLE
ID-1846: Performance improvements for basic-auth in Spring Security

### DIFF
--- a/src/main/java/no/idporten/userservice/config/SecurityConfiguration.java
+++ b/src/main/java/no/idporten/userservice/config/SecurityConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,8 +18,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -57,8 +56,10 @@ public class SecurityConfiguration {
                 .and()
                 .authenticationEntryPoint(new CustomOAuth2AuthenticationEntryPoint())
                 .and()
-                .httpBasic(withDefaults())
-                .formLogin(withDefaults());
+                .httpBasic()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         return http.build();
     }
@@ -75,7 +76,7 @@ public class SecurityConfiguration {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new BCryptPasswordEncoder(7);
     }
 
     @Bean


### PR DESCRIPTION
 Reduce time in bcrypt by not use default strength and not use sessions since only server-to-server communication here.