### PR TITLE
ID-1970: Ta i bruk siste versjon av idporten-access-log-spring-boot-starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <springdoc.version>1.6.9</springdoc.version>
         <logstash.logback.version>7.2</logstash.logback.version>
         <idporten-audit-log.version>0.0.17</idporten-audit-log.version>
+        <idporten-access-log.version>0.1.4</idporten-access-log.version>
         <nimbus.jose.jwt.version>9.23</nimbus.jose.jwt.version>
     </properties>
     <dependencies>
@@ -92,7 +93,7 @@
         <dependency>
             <groupId>no.idporten.logging</groupId>
             <artifactId>idporten-access-log-spring-boot-starter</artifactId>
-            <version>0.1.2</version>
+            <version>${idporten-access-log.version}</version>
         </dependency>
         <dependency>
             <groupId>no.idporten.validators</groupId>


### PR DESCRIPTION
Få med content-length i Tomcat access loggen (som bytes_sent). 
Version 0.1.4: https://github.com/felleslosninger/idporten-access-log-spring-boot-starter/releases/tag/0.1.4